### PR TITLE
Closes grib2 table after entry error

### DIFF
--- a/libsrc/NclGRIB2.c
+++ b/libsrc/NclGRIB2.c
@@ -8492,6 +8492,7 @@ static NhlErrorTypes Grib2ReadCodeTable
         ct->descrip = NULL;
         ct->shname = NULL;
         ct->units = NULL;
+        (void) fclose(fp);
         NclFree(ctf);
         return err = NhlWARNING;
     }


### PR DESCRIPTION
- Adds `(void) fclose(fp);` to line 8495 of libsrc/NclGRIB2.c to close
  grib2 table after an entry error. This fixes an issue of grib2 tables
  remaining open after an entry error is raised discussed in #1.

cc: @david-ian-brown @marylhaley 