### PR TITLE
Fix for building from source (two character modification to setup.py)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -357,7 +357,7 @@ except:
 try:
   EXTRA_OBJECTS = [os.environ["EXTRA_OBJECTS"]]
 except:
-  EXTRA_OBJECTS = ''
+  EXTRA_OBJECTS = []
 
 #
 # Done with environment variables.


### PR DESCRIPTION
Modified setup.py's EXTRA_OBJECTS variable to use an empty set ([] vs '') when the variable isn't found in the check.  The empty value is problematic for distutils, but NCAR's compiler wrappers eliminate the empty space, whereas directly calling the compilers does not - this leads to build problems on other systems.  (Usually hidden because it's installed via Conda in most cases.)

I'm very bad at python, so my terminology above is likely incorrect, but I'm pretty sure the diagnosis is right.  :-)